### PR TITLE
Fix collection parsing when the value is null

### DIFF
--- a/src/Eloquent/Casts/DynamicCasting.php
+++ b/src/Eloquent/Casts/DynamicCasting.php
@@ -44,7 +44,7 @@ class DynamicCasting implements CastsAttributes
             Metadata::TYPE_ARRAY => Arr::wrap(json_decode($value, true, 512, JSON_THROW_ON_ERROR)),
             Metadata::TYPE_BOOLEAN => (bool) $value,
             Metadata::TYPE_DATETIME => Carbon::parse($value),
-            Metadata::TYPE_COLLECTION => new Collection(Arr::wrap(json_decode($value, true, 512, JSON_THROW_ON_ERROR))),
+            Metadata::TYPE_COLLECTION => new Collection(Arr::wrap(json_decode($value ?? '{}', true, 512, JSON_THROW_ON_ERROR))),
             Metadata::TYPE_FLOAT => (float) $value,
             Metadata::TYPE_INTEGER => (int) $value,
             default => $value,


### PR DESCRIPTION
Hey, thanks for your work on this :)

This PR fixes the issue when a collection field is created with null as default value : 

```php
Setting::name('lorem')->collection();
```

When using a Json Resource in a controller, which would convert the `settings` attribute to it's json representation, the following error is thrown : 

```php
json_decode(null, true, 512, JSON_THROW_ON_ERROR)

DEPRECATED  json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in /var/www/marketing-smseval()'d code.

JsonException  Syntax error.
```

To address this issue, adding a default value to `"{}"` would parse the value as an empty collection : 

```php
json_decode($value ?? '{}', true, 512, JSON_THROW_ON_ERROR)
= []
```

It would be a nice idea to submit the package to [packagist](https://packagist.org) also.